### PR TITLE
fix: Remove fullname helm template helper

### DIFF
--- a/charts/ionoscloud-blockstorage-csi-driver/Chart.yaml
+++ b/charts/ionoscloud-blockstorage-csi-driver/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 keywords:
   - csi
   - ionos-cloud
-version: 0.1.1
+version: 0.2.0
 appVersion: "v1.7.0-rc.0"
 kubeVersion: ">=1.20.0-0"
 home: https://github.com/ionos-cloud/ionoscloud-blockstorage-csi-driver

--- a/charts/ionoscloud-blockstorage-csi-driver/README.md
+++ b/charts/ionoscloud-blockstorage-csi-driver/README.md
@@ -1,6 +1,6 @@
 # ionoscloud-blockstorage-csi-driver
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.7.0-rc.0](https://img.shields.io/badge/AppVersion-v1.7.0--rc.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.7.0-rc.0](https://img.shields.io/badge/AppVersion-v1.7.0--rc.0-informational?style=flat-square)
 
 **Homepage:** <https://github.com/ionos-cloud/ionoscloud-blockstorage-csi-driver>
 
@@ -34,7 +34,8 @@ The file must contain the datacenter ID of the VM in the following format:
 Provide the secret name during installation:
 
 ```console
-helm install -n kube-system ionoscloud-csi-driver oci://ghcr.io/ionos-cloud/helm-charts/ionoscloud-blockstorage-csi-driver \
+helm install -n kube-system ionoscloud-blockstorage-csi-driver \
+    oci://ghcr.io/ionos-cloud/helm-charts/ionoscloud-blockstorage-csi-driver \
     --set tokenSecretName=csi-secret
 ```
 
@@ -48,9 +49,11 @@ Should you need to install multiple CSI drivers using tokens from the same users
 you need to set the `clusterName` value on installation.
 
 ```console
-helm install -n kube-system ionoscloud-csi-driver oci://ghcr.io/ionos-cloud/helm-charts/ionoscloud-blockstorage-csi-driver \
+helm install -n kube-system ionoscloud-blockstorage-csi-driver \
+    oci://ghcr.io/ionos-cloud/helm-charts/ionoscloud-blockstorage-csi-driver \
     --set tokenSecretName=csi-secret --set clusterName=production
-helm install -n kube-system ionoscloud-csi-driver oci://ghcr.io/ionos-cloud/helm-charts/ionoscloud-blockstorage-csi-driver \
+helm install -n kube-system ionoscloud-blockstorage-csi-driver \
+    oci://ghcr.io/ionos-cloud/helm-charts/ionoscloud-blockstorage-csi-driver \
     --set tokenSecretName=csi-secret --set clusterName=staging
 ```
 
@@ -184,13 +187,12 @@ helm install -n kube-system ionoscloud-csi-driver oci://ghcr.io/ionos-cloud/helm
 | className | string | `"ionos-cloud"` | Name of VolumeSnapshotClass. Also used as prefix for StorageClasses. |
 | clusterName | string | `"k8s"` | Name used to identify managed storage resources. |
 | driverName | string | `"cloud.ionos.com"` | Name of the driver in the storage class. |
-| fullnameOverride | string | `""` | Specify a custom fullname override. This only influences Kubernetes resource names, not properties. |
 | nameOverride | string | `""` | Specify a custom name override. This only influences Kubernetes resource names, not properties. |
 | registry | string | Omit if empty | Specify a custom registry name that will be used as prefix for all images. Useful when pulling images from a registry mirror. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `true` | Automatically mount a ServiceAccount's API credentials? |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
-| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated from template |
 | tokenSecretName | string | `""` | Name of the secret that contains the token used for cloud API authentication. Must contain the key "token". |
 
 [cloud-api]: https://api.ionos.com/docs/cloud/v6/

--- a/charts/ionoscloud-blockstorage-csi-driver/README.md.gotmpl
+++ b/charts/ionoscloud-blockstorage-csi-driver/README.md.gotmpl
@@ -34,7 +34,8 @@ The file must contain the datacenter ID of the VM in the following format:
 Provide the secret name during installation:
 
 ```console
-helm install -n kube-system ionoscloud-csi-driver oci://ghcr.io/ionos-cloud/helm-charts/ionoscloud-blockstorage-csi-driver \
+helm install -n kube-system ionoscloud-blockstorage-csi-driver \
+    oci://ghcr.io/ionos-cloud/helm-charts/ionoscloud-blockstorage-csi-driver \
     --set tokenSecretName=csi-secret
 ```
 
@@ -48,9 +49,11 @@ Should you need to install multiple CSI drivers using tokens from the same users
 you need to set the `clusterName` value on installation.
 
 ```console
-helm install -n kube-system ionoscloud-csi-driver oci://ghcr.io/ionos-cloud/helm-charts/ionoscloud-blockstorage-csi-driver \
+helm install -n kube-system ionoscloud-blockstorage-csi-driver \
+    oci://ghcr.io/ionos-cloud/helm-charts/ionoscloud-blockstorage-csi-driver \
     --set tokenSecretName=csi-secret --set clusterName=production
-helm install -n kube-system ionoscloud-csi-driver oci://ghcr.io/ionos-cloud/helm-charts/ionoscloud-blockstorage-csi-driver \
+helm install -n kube-system ionoscloud-blockstorage-csi-driver \
+    oci://ghcr.io/ionos-cloud/helm-charts/ionoscloud-blockstorage-csi-driver \
     --set tokenSecretName=csi-secret --set clusterName=staging
 ```
 

--- a/charts/ionoscloud-blockstorage-csi-driver/templates/_helpers.tpl
+++ b/charts/ionoscloud-blockstorage-csi-driver/templates/_helpers.tpl
@@ -6,24 +6,6 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "csi-driver.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "csi-driver.chart" -}}
@@ -69,7 +51,7 @@ Create the name of the service account to use
 */}}
 {{- define "csi-driver.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "csi-driver.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "csi-driver.name" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/ionoscloud-blockstorage-csi-driver/templates/daemonset.yaml
+++ b/charts/ionoscloud-blockstorage-csi-driver/templates/daemonset.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "csi-driver.fullname" . }}
+  name: {{ include "csi-driver.name" . }}
   labels:
     {{- include "csi-driver.labels" . | nindent 4 }}
 spec:

--- a/charts/ionoscloud-blockstorage-csi-driver/templates/deployment.yaml
+++ b/charts/ionoscloud-blockstorage-csi-driver/templates/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "csi-driver.fullname" . }}-controller
+  name: {{ include "csi-driver.name" . }}-controller
   labels:
     {{- include "csi-driver.labels" . | nindent 4 }}
 spec:

--- a/charts/ionoscloud-blockstorage-csi-driver/templates/podmonitor.yaml
+++ b/charts/ionoscloud-blockstorage-csi-driver/templates/podmonitor.yaml
@@ -5,7 +5,7 @@ metadata:
   {{- if .Values.monitoring.nameOverride }}
   name: {{ .Values.monitoring.nameOverride }}
   {{- else }}
-  name: {{ include "csi-driver.fullname" . }}
+  name: {{ include "csi-driver.name" . }}
   {{- end }}
   {{- if .Values.monitoring.namespace }}
   namespace: {{ .Values.monitoring.namespace }}

--- a/charts/ionoscloud-blockstorage-csi-driver/templates/rbac/clusterrole.yaml
+++ b/charts/ionoscloud-blockstorage-csi-driver/templates/rbac/clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "csi-driver.fullname" . }}
+  name: {{ include "csi-driver.name" . }}
   labels:
     {{- include "csi-driver.labels" . | nindent 4 }}
 rules:

--- a/charts/ionoscloud-blockstorage-csi-driver/templates/rbac/clusterrolebinding.yaml
+++ b/charts/ionoscloud-blockstorage-csi-driver/templates/rbac/clusterrolebinding.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "csi-driver.fullname" . }}
+  name: {{ include "csi-driver.name" . }}
   labels:
     {{- include "csi-driver.labels" . | nindent 4 }}
 subjects:
@@ -12,4 +12,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "csi-driver.fullname" . }}
+  name: {{ include "csi-driver.name" . }}

--- a/charts/ionoscloud-blockstorage-csi-driver/templates/rbac/role.yaml
+++ b/charts/ionoscloud-blockstorage-csi-driver/templates/rbac/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "csi-driver.fullname" . }}
+  name: {{ include "csi-driver.name" . }}
   labels:
     {{- include "csi-driver.labels" . | nindent 4 }}
 rules:

--- a/charts/ionoscloud-blockstorage-csi-driver/templates/rbac/rolebinding.yaml
+++ b/charts/ionoscloud-blockstorage-csi-driver/templates/rbac/rolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "csi-driver.fullname" . }}
+  name: {{ include "csi-driver.name" . }}
   labels:
     {{- include "csi-driver.labels" . | nindent 4 }}
 subjects:
@@ -13,5 +13,5 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "csi-driver.fullname" . }}
+  name: {{ include "csi-driver.name" . }}
 {{- end }}

--- a/charts/ionoscloud-blockstorage-csi-driver/values.yaml
+++ b/charts/ionoscloud-blockstorage-csi-driver/values.yaml
@@ -13,8 +13,6 @@ className: ionos-cloud
 
 # -- Specify a custom name override. This only influences Kubernetes resource names, not properties.
 nameOverride: ""
-# -- Specify a custom fullname override. This only influences Kubernetes resource names, not properties.
-fullnameOverride: ""
 
 # -- (string) Specify a custom registry name that will be used as prefix for all images.
 # Useful when pulling images from a registry mirror.
@@ -28,7 +26,7 @@ serviceAccount:
   automount: true
   # -- Annotations to add to the service account
   annotations: {}
-  # -- The name of the service account to use. If not set and create is true, a name is generated using the fullname template
+  # -- The name of the service account to use. If not set and create is true, a name is generated from template
   name: ""
 
 driver:


### PR DESCRIPTION
## What does this fix or implement?

I copied the install instructions from the chart README for a test and noticed this warning:

```
W0612 20:33:14.929907  209502 warnings.go:70] metadata.name: this is used in Pod names and hostnames, which can result in surprising behavior; a DNS label is recommended: [must be no more than 63 characters]
```

Since the chart name is already very long adding any other name can easily exceed the limit for pod names and this can
easily be missed.

Having the name of all resources be the same as the helm chart should be fine, because you can only install one instance
anyways.

## Checklist

<!-- Please check the completed items below -->
<!-- Not all changes require documentation updates or tests to be added or updated -->

- [x] PR title contains [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) markers (`feat:`, `fix:`, `docs:`, etc.)
- [x] Helm chart version bumped
- [ ] Tests added or updated
- [x] Documentation updated
- [ ] GitHub issue linked if any
