### PR TITLE
ci: Enforce semantic commit PR titles

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,6 @@
 <!-- Please check the completed items below -->
 <!-- Not all changes require documentation updates or tests to be added or updated -->
 
-- [ ] PR title contains [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) markers (`feat:`, `fix:`, `docs:`, etc.)
-- [ ] Helm chart version bumped
 - [ ] Tests added or updated
 - [ ] Documentation updated
 - [ ] GitHub issue linked if any

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     interval: "weekly"
   commit-message:
     prefix: "chore:"
+  labels:
+    - "dependabot"
 
 - package-ecosystem: "github-actions"
   directory: "/"
@@ -14,3 +16,5 @@ updates:
     interval: "daily"
   commit-message:
     prefix: "chore:"
+  labels:
+    - "dependabot"

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,9 +22,9 @@ permissions:
   pull-requests: read
 
 jobs:
-  check-pr:
+  validate-title:
     if: github.event.pull_request.draft == false
-    name: Check
+    name: Validate PR title
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5.5.2

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -8,6 +8,7 @@ on:
       - opened
       - edited
       - synchronize
+      - ready_for_review
   pull_request_target:
     branches:
       - main
@@ -15,6 +16,7 @@ on:
       - opened
       - edited
       - synchronize
+      - ready_for_review
 
 permissions:
   pull-requests: read

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,14 +1,20 @@
 name: PR check
 
 on:
-  pull_request: &filters
+  pull_request:
     branches:
       - main
     types:
       - opened
       - edited
       - synchronize
-  pull_request_target: *filters
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - synchronize
 
 permissions:
   pull-requests: read

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,24 @@
+name: PR check
+
+on:
+  pull_request: &filters
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - synchronize
+  pull_request_target: *filters
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check-pr:
+    if: github.event.pull_request.draft == false
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.5.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,8 @@ community looks forward to your contributions. 🎉
   - [Reporting Bugs](#reporting-bugs)
   - [Suggesting Enhancements](#suggesting-enhancements)
   - [Your First Code Contribution](#your-first-code-contribution)
+  - [Open a pull request](#open-a-pull-request)
 - [Style guides](#style-guides)
-  - [Pull requests](#pull-requests)
 
 
 ## I Have a Question
@@ -134,17 +134,14 @@ pre-commit install
 The hooks are set up to perform basic validations on your code, like fixing newlines at the end of a file or linting
 changed helm files.
 
+### Open a pull request
+
+Pull request titles must conform to [convention commit](https://www.conventionalcommits.org/en/v1.0.0/) specification.
+This is enforced by a GitHub action.
+
+If your pull request is a work-in-progress (WIP) it should be opened as [draft pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
+
 ## Style guides
-
-### Pull requests
-
-Pull request title and description will be used as squash commit message after the merge.
-Ensure that they follow the [convention commit](https://www.conventionalcommits.org/en/v1.0.0/) specification.
-
-The pull request title will correspond to the first line in the commit message, with the description populating the
-rest.
-
-Single commits in a pull request do not need to adhere to this.
 
 ## Attribution
 This guide is based on the **contributing-gen**. [Make your own](https://github.com/bttger/contributing-gen)!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,7 @@ changed helm files.
 
 ### Open a pull request
 
-Pull request titles must conform to [convention commit](https://www.conventionalcommits.org/en/v1.0.0/) specification.
+Pull request titles must conform to [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification.
 This is enforced by a GitHub action.
 
 If your pull request is a work-in-progress (WIP) it should be opened as [draft pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).


### PR DESCRIPTION
Add pull request checks for ensure the PR title conforms to semantic commit.

Also configure dependabot to label its PRs so that they can be more easily distinguished for automation purposes.
