### PR TITLE
chore: bump tj-actions

### DIFF
--- a/.github/workflows/chart-ci.yml
+++ b/.github/workflows/chart-ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45.0.7
+        uses: tj-actions/changed-files@v46.0.3
         with:
           files: |
             charts/**


### PR DESCRIPTION
Fix [CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3/dependabot)