### PR TITLE
fix: Run node-driver-registrar in privileged mode

### DIFF
--- a/charts/ionoscloud-blockstorage-csi-driver/Chart.yaml
+++ b/charts/ionoscloud-blockstorage-csi-driver/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 keywords:
   - csi
   - ionos-cloud
-version: 0.4.0
+version: 0.4.1
 appVersion: "v1.9.0-rc.1"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/ionos-cloud/ionoscloud-blockstorage-csi-driver

--- a/charts/ionoscloud-blockstorage-csi-driver/README.md
+++ b/charts/ionoscloud-blockstorage-csi-driver/README.md
@@ -1,6 +1,6 @@
 # ionoscloud-blockstorage-csi-driver
 
-![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.9.0-rc.1](https://img.shields.io/badge/AppVersion-v1.9.0--rc.1-informational?style=flat-square)
+![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.9.0-rc.1](https://img.shields.io/badge/AppVersion-v1.9.0--rc.1-informational?style=flat-square)
 
 **Homepage:** <https://github.com/ionos-cloud/ionoscloud-blockstorage-csi-driver>
 

--- a/charts/ionoscloud-blockstorage-csi-driver/templates/daemonset.yaml
+++ b/charts/ionoscloud-blockstorage-csi-driver/templates/daemonset.yaml
@@ -87,10 +87,10 @@ spec:
               mountPath: /etc
         - name: node-driver-registrar
           securityContext:
-            allowPrivilegeEscalation: false
+            allowPrivilegeEscalation: true
             capabilities:
               drop: ["ALL"]
-            privileged: false
+            privileged: true
             readOnlyRootFilesystem: true
           image: "{{ include "image.registry" . }}{{ .Values.registrar.image.repository }}:{{ .Values.registrar.image.tag }}"
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
## What does this fix or implement?

Run node-driver-registrar container in privileged mode to allow running on RHEL with SELinux enabled.

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] GitHub issue linked if any
